### PR TITLE
add file extension to end of user avatar URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -134,7 +134,7 @@ app.get("/v1/user/:id/", cors({
 
                     let avatarLink = null;
                     if (json.avatar)
-                        avatarLink = `https://cdn.discordapp.com/avatars/${json.id}/${json.avatar}`;
+                        avatarLink = `https://cdn.discordapp.com/avatars/${json.id}/${json.avatar}.webp`;
 
                     let bannerLink = null;
                     if (json.banner)


### PR DESCRIPTION
User avatar link initially went to nowhere but when added .webp extension, showed up. Tried to do similar thing to banners, as they also go nowhere and lack a file extension, thought I was unable to figure out what extension they use. In the Discord app it seems to be straight code programmed in as paint or something, it's not a link to anywhere.