### PR TITLE
Add file structure and vercel.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Data is cached for 3 hours (or until the Redis Server restarts)
 
 ## Usage
 
-You can freely access the API [here](https://discordlookup.mesavirep.xyz)
+You can freely access the API [here](https://discordlookup.mesavirep.xyz) <img src="https://img.shields.io/badge/-OFFLINE-red?label=Status" alt="Status" height="15">
+
+Or you can deploy your own instance of the API through Vercel:
+
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FjSydorowicz21%2Fdiscord-lookup-api&env=TOKEN&envDescription=Discord%20bot%20token&envLink=https%3A%2F%2Fdiscord.com%2Fdevelopers%2Fdocs%2Fquick-start%2Fgetting-started&project-name=discord-lookup-api&repository-name=discord-lookup-api)
+> **Note**
+> This version does not have caching due to Vercel limitations. You must also have a Discord Bot Token to use the API. You can get one [here](https://discord.com/developers/docs/quick-start/getting-started)
+>
 
 Right now, you must specify an ID to the link (a proper website is currently in development)
 

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,159 @@
+/**
+    This is a simple express server that fetches data from the Discord API and returns it in a more readable format.
+    This is a cut down version of the API server, used for deploying to vercel.
+    This version does not include caching, and is not recommended for large production use.
+ */
+const express = require("express");
+const fetch = require("node-fetch");
+const cors = require("cors");
+
+const snowflakeToDate = require("../utils");
+const { USER_FLAGS, APPLICATION_FLAGS } = require("../Constants");
+
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+
+app.use((req, res, next) => {
+    res.append("Access-Control-Allow-Origin", ["*"]);
+    res.append("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE");
+    res.append("Access-Control-Allow-Headers", "Content-Type");
+    next();
+});
+
+app.get("/", (req, res) => {
+    res.send("root page");
+});
+
+app.get("/v1/guild/:id", cors({
+    methods: ["GET"]
+}), async (req, res) => {
+    let id = req.params.id;
+    fetch(`https://canary.discord.com/api/v10/guilds/${id}/widget.json`, {
+        headers: {
+            "Content-Type": "application/json",
+        },
+    })
+    .then((res) => res.json())
+    .then((json) => {
+        if (json.code && json.code === 50004) {
+            res.send({
+                "error": "The guild is either non-existant, unavailable, or has Server Widget/Discovery disabled."
+            })
+            return;
+        }
+
+        let output = {
+            id: json.id,
+            name: json.name,
+            instant_invite: json.instant_invite,
+            presence_count: json.presence_count
+        }
+
+        res.send(output);
+    })
+})
+
+app.get("/v1/application/:id", cors({
+    methods: ["GET"]
+}), async (req, res) => {
+    fetch(`https://canary.discord.com/api/v10/applications/${req.params.id}/rpc`, {
+        headers: {
+            "Content-Type": "application/json",
+        },
+    })
+    .then((res) => res.json())
+    .then((json) => {
+        let hashIcon = json.icon;
+        json.icon = `https://cdn.discordapp.com/avatars/${json.id}/${hashIcon}`
+
+        let publicFlags = [];
+        let flags = json.flags;
+        APPLICATION_FLAGS.forEach((flag) => {
+            if (json.flags && flag.bitwise) publicFlags.push(flag.flag);
+        });
+        json.flags = {
+            bits: flags,
+            detailed: publicFlags
+        }
+
+        res.send(json);
+    })
+})
+
+app.get("/v1/user/:id/", cors({
+    methods: ["GET"]
+}), async (req, res) => {
+    let id = req.params.id;
+
+    try {
+        fetch(`https://canary.discord.com/api/v10/users/${id}`, {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bot ${process.env.TOKEN}`,
+            },
+        })
+        .then((res) => res.json())
+        .then((json) => {
+            if (json.message) return res.send(json);
+
+            let publicFlags = [];
+
+            let premiumTypes = {
+                0: "None",
+                1: "Nitro Classic",
+                2: "Nitro",
+                3: "Nitro Basic"
+            }
+
+            USER_FLAGS.forEach((flag) => {
+                if (json.public_flags & flag.bitwise) publicFlags.push(flag.flag);
+            });
+
+            let avatarLink = null;
+            if (json.avatar)
+                avatarLink = `https://cdn.discordapp.com/avatars/${json.id}/${json.avatar}`;
+
+            let bannerLink = null;
+            if (json.banner)
+                bannerLink = `https://cdn.discordapp.com/banners/${json.id}/${json.banner}?size=480`;
+
+            let output = {
+                id: json.id,
+                created_at: snowflakeToDate(json.id),
+                username: json.username,
+                avatar: {
+                    id: json.avatar,
+                    link: avatarLink,
+                    is_animated: json.avatar != null && json.avatar.startsWith("a_"),
+                },
+                avatar_decoration: json.avatar_decoration_data,
+                badges: publicFlags,
+                premium_type: premiumTypes[json.premium_type],
+                accent_color: json.accent_color,
+                global_name: json.global_name,
+                banner: {
+                    id: json.banner,
+                    link: bannerLink,
+                    is_animated: json.banner != null && json.banner.startsWith("a_"),
+                    color: json.banner_color,
+                },
+                raw: json
+            }
+
+            res.send(output);
+        });
+    } catch (err) {
+        console.log(err);
+    }
+});
+
+app.get("*", function (req, res) {
+    res.status(404).send("404 - Not Found");
+});
+
+app.listen(3000, "127.0.0.1");
+console.log(`Server opened at port ${3000}`);
+
+module.exports = app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,1 @@
+{ "version": 2, "rewrites": [{ "source": "/(.*)", "destination": "/api" }] }


### PR DESCRIPTION
This PR allows deploying to Vercel. Created the file structure necessary for Vercel to identify and deploy the API. The cache had to be stripped out of the Vercel version due to current limitations.  Updated README to add deploy with Vercel button and indicated the current status of the previously online API.

The link in the deploy with vercel button currently points to the forked repo until merged with main to allow users to deploy their own copies in the mean time since the previously hosted API is down and #17 shows a need for the project still. Should be modified to point back to mesalytic/discord-lookup-api when ready to be merged with main.